### PR TITLE
Add --export CLI option to generate exported interfaces

### DIFF
--- a/py_ts_interfaces/cli.py
+++ b/py_ts_interfaces/cli.py
@@ -10,7 +10,6 @@ from py_ts_interfaces import Interface, Parser
 
 def main() -> None:
     args = get_args_namespace()
-
     # parse datatype mapping
     datatype_map = {}
     for typemap in args.typemap:
@@ -69,6 +68,7 @@ def get_args_namespace() -> argparse.Namespace:
         required=False,
         nargs="+",
         help="Define custom simple data type alises. For instance, to map custom type `String` to python builtin `str`: `--typemap String str`. Use flag several times to specify several mappings.",
+        default=[],
     )
     argparser.add_argument("-a, --append", action="store_true", dest="should_append")
     return argparser.parse_args()

--- a/py_ts_interfaces/cli.py
+++ b/py_ts_interfaces/cli.py
@@ -12,7 +12,9 @@ def main() -> None:
     if os.path.isdir(args.outpath):
         raise Exception(f"{args.outpath} is a directory! Aborting.")
 
-    interface_parser = Parser(f"{Interface.__module__}.{Interface.__name__}")
+    interface_parser = Parser(
+        f"{Interface.__module__}.{Interface.__name__}", export=args.export
+    )
 
     for code in read_code_from_files(get_paths_to_py_files(args.paths)):
         interface_parser.parse(code)
@@ -44,6 +46,7 @@ def get_args_namespace() -> argparse.Namespace:
     argparser.add_argument(
         "-o, --outpath", action="store", default="interface.ts", dest="outpath"
     )
+    argparser.add_argument("-e", "--export", action="store_true", required=False)
     argparser.add_argument("-a, --append", action="store_true", dest="should_append")
     return argparser.parse_args()
 

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -38,9 +38,10 @@ PreparedInterfaces = Dict[str, InterfaceAttributes]
 
 
 class Parser:
-    def __init__(self, interface_qualname: str) -> None:
+    def __init__(self, interface_qualname: str, export: bool = True) -> None:
         self.interface_qualname = interface_qualname
         self.prepared: PreparedInterfaces = {}
+        self._export = export
 
     def parse(self, code: str) -> None:
         queue = deque([astroid.parse(code)])
@@ -76,7 +77,8 @@ class Parser:
         serialized: List[str] = []
 
         for interface, attributes in self.prepared.items():
-            s = f"interface {interface} {{\n"
+            s = "export " if self._export else ""
+            s += f"interface {interface} {{\n"
             for attribute_name, attribute_type in attributes.items():
                 s += f"    {attribute_name}: {attribute_type};\n"
             s += "}"

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -1,6 +1,8 @@
+import sys
 import warnings
 from collections import deque
 from typing import Dict, List, NamedTuple, Optional, Union
+
 
 import astroid
 
@@ -38,10 +40,24 @@ PreparedInterfaces = Dict[str, InterfaceAttributes]
 
 
 class Parser:
-    def __init__(self, interface_qualname: str, export: bool = True) -> None:
+    def __init__(
+        self,
+        interface_qualname: str,
+        export: bool = True,
+        datatype_map: Dict[str, str] = {},
+    ) -> None:
         self.interface_qualname = interface_qualname
         self.prepared: PreparedInterfaces = {}
         self._export = export
+
+        # make sure that custom datamap resolves to a known datatype
+        for dtype in datatype_map.values():
+            if not dtype in TYPE_MAP.keys():
+                print(f"Unkown datatype {dtype}")
+                sys.exit(1)
+
+        # add custom datatypes
+        TYPE_MAP.update(datatype_map)
 
     def parse(self, code: str) -> None:
         queue = deque([astroid.parse(code)])


### PR DESCRIPTION
# Example

`py-ts-interfaces example.py --export` generates:

```typescript
export interface UserPublic {
    id: string;
    username: string;
}
```

and `py-ts-interfaces example.py ` generates:

```typescript
interface UserPublic {
    id: string;
    username: string;
}
```