### PR TITLE
Adding support for datetime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ variables.
 | float                           | number                        |
 | complex                         | number                        |
 | bool                            | boolean                       |
+| datetime*                        | Date                          |
 | List                            | Array\<any\>                  |
 | Tuple                           | [any]                         |
 | Dict                            | Record<any, any>              |
@@ -142,6 +143,8 @@ variables.
 | Dict[T, U]                      | Record<T, U>                  |
 | Optional[T]                     | T \| null                     |
 | Union[T, U, V]                  | T \| U \| V                   |
+
+*_Note that datetime (from the datetime library) requires to be defined exactly like that_
 
 ## Planned Supported Mappings
 

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -19,6 +19,7 @@ TYPE_MAP: Dict[str, str] = {
     "int": "number",
     "float": "number",
     "complex": "number",
+    "datetime": "Date",
     "Any": "any",
     "Dict": "Record<any, any>",
     "List": "Array<any>",

--- a/py_ts_interfaces/tests/tests.py
+++ b/py_ts_interfaces/tests/tests.py
@@ -222,6 +222,7 @@ def test_parser_flush(
         ("ace: float", ("ace", "number")),
         ("ace: complex", ("ace", "number")),
         ("ace: bool", ("ace", "boolean")),
+        ("bar: datetime", ("bar", "Date")),
         ("ace: Any", ("ace", "any")),
         ("foo: List", ("foo", "Array<any>")),
         ("foo: Dict", ("foo", "Record<any, any>")),
@@ -234,7 +235,9 @@ def test_parser_flush(
         ("ace: Optional[complex]", ("ace", "number | null")),
         ("ace: Optional[bool]", ("ace", "boolean | null")),
         ("ace: Optional[Any]", ("ace", "any | null")),
+        ("ace: Optional[datetime]", ("ace", "Date | null")),
         ("foo: Dict[str, int]", ("foo", "Record<string, number>")),
+        ("ace: Dict[datetime, str]", ("ace", "Record<Date, string>")),
         (
             "bar: Optional[Tuple[str, int]]",
             ("bar", "[string, number] | null"),


### PR DESCRIPTION
This PR adds support for the `datetime.datetime` type.

The type in the dataclass must be defined as `foo: datetime`, otherwise it will return `UNKNOWN`.

