### PR TITLE
add support for exporting generated interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You may also use the following arguments:
 * `-o, --output [filepath]`:  where the file will be saved. default is `interface.ts`.
 * `-a, --append`:  by default each run will overwrite the output file. this flag
 allows only appends.  Be warned, duplicate interfaces are not tested.
+* `-e, --export`:  whether the interface definitions should be prepended with `export`; 
+private python classes will be omitted. 
 
 
 3. The resulting file will look like this:

--- a/py_ts_interfaces/cli.py
+++ b/py_ts_interfaces/cli.py
@@ -17,7 +17,7 @@ def main() -> None:
     for code in read_code_from_files(get_paths_to_py_files(args.paths)):
         interface_parser.parse(code)
 
-    result = interface_parser.flush()
+    result = interface_parser.flush(args.should_export)
     if not result:
         warnings.warn("Did not have anything to write to the file!", UserWarning)
 
@@ -45,6 +45,7 @@ def get_args_namespace() -> argparse.Namespace:
         "-o, --outpath", action="store", default="interface.ts", dest="outpath"
     )
     argparser.add_argument("-a, --append", action="store_true", dest="should_append")
+    argparser.add_argument("-e, --export", action="store_true", dest="should_export")
     return argparser.parse_args()
 
 

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -74,11 +74,12 @@ class Parser:
             self.prepared[current.name] = get_types_from_classdef(current)
         ensure_possible_interface_references_valid(self.prepared)
 
-    def flush(self) -> str:
+    def flush(self, should_export: bool) -> str:
         serialized: List[str] = []
 
         for interface, attributes in self.prepared.items():
-            s = f"interface {interface} {{\n"
+            s = self._get_interface_string(interface, should_export)
+            s += " {\n"
             for attribute_name, attribute_type in attributes.items():
                 s += f"    {attribute_name}: {attribute_type};\n"
             s += "}"
@@ -86,6 +87,12 @@ class Parser:
 
         self.prepared.clear()
         return "\n\n".join(serialized).strip() + "\n"
+
+    @staticmethod
+    def _get_interface_string(interface: str, should_export: bool):
+        if not should_export or interface[0]=="_":
+            return f"interface {interface}"
+        return f"export interface {interface}"
 
 
 def get_types_from_classdef(node: astroid.ClassDef) -> Dict[str, str]:


### PR DESCRIPTION
As mentioned in one of the Issues, the generated interface file cannot be used as a module. This change proposes a fix that does not change the default behavior, but instead provides an additional flag, `-e` or `--export`, to add an `export` classifier to the TypeScript interfaces. Additionally, source interfaces with a leading underscore are considered private and won't be given this classifier.