### PR TITLE
Fix problem with dictionaries that have the same type as key and value

### DIFF
--- a/py_ts_interfaces/tests/tests.py
+++ b/py_ts_interfaces/tests/tests.py
@@ -235,6 +235,7 @@ def test_parser_flush(
         ("ace: Optional[bool]", ("ace", "boolean | null")),
         ("ace: Optional[Any]", ("ace", "any | null")),
         ("foo: Dict[str, int]", ("foo", "Record<string, number>")),
+        ("foo: Dict[int, int]", ("foo", "Record<number, number>")),
         (
             "bar: Optional[Tuple[str, int]]",
             ("bar", "[string, number] | null"),


### PR DESCRIPTION
I detected a problem when using dictionaries where key and value have the same type. For example, the output produced for 

```python
class Test(Interface):
    foo: Dict[int, int]
``` 

is 

```typescript
interface Test {
    foo: Record<number>
}
``` 

when it should be `Record<number, number>`. I saw this is problem happened because `get_inner_tuple_types` did not insert duplicated types, so I changed it to allow duplicates and then deduplicate only when using Union (as denoted by `delimiter == " | "`. I think it could be made cleaner by changing `get_inner_tuple_delimiter` to return a boolean or flag that denotes whether we have type enumeration or type union, and then setting delimiter and deduplication based on that, but I preferred to implement the solution in this way to avoid changing too many functions.