### PR TITLE
Add support for camelization of interface names and attributes

### DIFF
--- a/py_ts_interfaces/cli.py
+++ b/py_ts_interfaces/cli.py
@@ -17,7 +17,7 @@ def main() -> None:
     for code in read_code_from_files(get_paths_to_py_files(args.paths)):
         interface_parser.parse(code)
 
-    result = interface_parser.flush()
+    result = interface_parser.flush(args.should_camelize)
     if not result:
         warnings.warn("Did not have anything to write to the file!", UserWarning)
 
@@ -45,6 +45,9 @@ def get_args_namespace() -> argparse.Namespace:
         "-o, --outpath", action="store", default="interface.ts", dest="outpath"
     )
     argparser.add_argument("-a, --append", action="store_true", dest="should_append")
+    argparser.add_argument(
+        "-c, --camelize", action="store_true", dest="should_camelize",
+        help="Camelize the interface names and attributes.")
     return argparser.parse_args()
 
 

--- a/py_ts_interfaces/cli.py
+++ b/py_ts_interfaces/cli.py
@@ -46,8 +46,11 @@ def get_args_namespace() -> argparse.Namespace:
     )
     argparser.add_argument("-a, --append", action="store_true", dest="should_append")
     argparser.add_argument(
-        "-c, --camelize", action="store_true", dest="should_camelize",
-        help="Camelize the interface names and attributes.")
+        "-c, --camelize",
+        action="store_true",
+        dest="should_camelize",
+        help="Camelize the interface names and attributes.",
+    )
     return argparser.parse_args()
 
 

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from collections import deque
 from typing import Dict, List, NamedTuple, Optional, Union
@@ -39,6 +40,14 @@ InterfaceAttributes = Dict[str, str]
 PreparedInterfaces = Dict[str, InterfaceAttributes]
 
 
+def camelize(s):
+    """Convert a string from underscore naming convention to camel-case.
+    """
+    # Force a character to be at the start, so that strings starting with underscore
+    # do not get that initial underscore removed.
+    return re.sub(r'(.)_([a-z])', lambda x: x.group(1) + x.group(2).upper(), s)
+
+
 class Parser:
     def __init__(self, interface_qualname: str) -> None:
         self.interface_qualname = interface_qualname
@@ -74,12 +83,18 @@ class Parser:
             self.prepared[current.name] = get_types_from_classdef(current)
         ensure_possible_interface_references_valid(self.prepared)
 
-    def flush(self) -> str:
+    def flush(self, should_camelize: bool) -> str:
         serialized: List[str] = []
 
         for interface, attributes in self.prepared.items():
+            if should_camelize:
+                interface = camelize(interface)
+
             s = f"interface {interface} {{\n"
             for attribute_name, attribute_type in attributes.items():
+                if should_camelize:
+                    attribute_name = camelize(attribute_name)
+
                 s += f"    {attribute_name}: {attribute_type};\n"
             s += "}"
             serialized.append(s)

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -40,12 +40,11 @@ InterfaceAttributes = Dict[str, str]
 PreparedInterfaces = Dict[str, InterfaceAttributes]
 
 
-def camelize(s):
-    """Convert a string from underscore naming convention to camel-case.
-    """
+def camelize(s: str) -> str:
+    """Convert a string from underscore naming convention to camel-case."""
     # Force a character to be at the start, so that strings starting with underscore
     # do not get that initial underscore removed.
-    return re.sub(r'(?=.)_([a-z])', lambda x: x.group(1).upper(), s)
+    return re.sub(r"(?=.)_([a-z])", lambda x: x.group(1).upper(), s)
 
 
 class Parser:

--- a/py_ts_interfaces/parser.py
+++ b/py_ts_interfaces/parser.py
@@ -45,7 +45,7 @@ def camelize(s):
     """
     # Force a character to be at the start, so that strings starting with underscore
     # do not get that initial underscore removed.
-    return re.sub(r'(.)_([a-z])', lambda x: x.group(1) + x.group(2).upper(), s)
+    return re.sub(r'(?=.)_([a-z])', lambda x: x.group(1).upper(), s)
 
 
 class Parser:

--- a/py_ts_interfaces/tests/tests.py
+++ b/py_ts_interfaces/tests/tests.py
@@ -216,12 +216,15 @@ def test_parser_flush(
 @pytest.mark.parametrize(
     "prepared_mocks, expected",
     [
-        ({"abc": {"snake_case": "ghi"}}, """interface abc {\n    snakeCase: ghi;\n}\n"""),
+        (
+            {"abc": {"snake_case": "ghi"}},
+            """interface abc {\n    snakeCase: ghi;\n}\n""",
+        ),
         (
             {"abc": {"word_one_two": "ghi", "a_b_c": "mno"}},
             """interface abc {\n    wordOneTwo: ghi;\n    aBC: mno;\n}\n""",
         ),
-        ({"multiple__underscore": {}}, """interface multiple_Underscore {\n}\n""")
+        ({"multiple__underscore": {}}, """interface multiple_Underscore {\n}\n"""),
     ],
 )
 def test_parser_flush_camelized(
@@ -234,6 +237,7 @@ def test_parser_flush_camelized(
     parser = Parser(interface_qualname)
     parser.prepared = prepared_mocks
     assert parser.flush(True) == expected
+
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize(

--- a/py_ts_interfaces/tests/tests.py
+++ b/py_ts_interfaces/tests/tests.py
@@ -210,8 +210,30 @@ def test_parser_flush(
     """
     parser = Parser(interface_qualname)
     parser.prepared = prepared_mocks
-    assert parser.flush() == expected
+    assert parser.flush(False) == expected
 
+
+@pytest.mark.parametrize(
+    "prepared_mocks, expected",
+    [
+        ({"abc": {"snake_case": "ghi"}}, """interface abc {\n    snakeCase: ghi;\n}\n"""),
+        (
+            {"abc": {"word_one_two": "ghi", "a_b_c": "mno"}},
+            """interface abc {\n    wordOneTwo: ghi;\n    aBC: mno;\n}\n""",
+        ),
+        ({"multiple__underscore": {}}, """interface multiple_Underscore {\n}\n""")
+    ],
+)
+def test_parser_flush_camelized(
+    prepared_mocks: Any, expected: str, interface_qualname: str
+) -> None:
+    """
+    When the parser flushes its prepared interfaces, it should generate
+    valid TS interfaces.
+    """
+    parser = Parser(interface_qualname)
+    parser.prepared = prepared_mocks
+    assert parser.flush(True) == expected
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize(


### PR DESCRIPTION
Standard case pattern in Python is underscore_case, while in TypeScript it's camelCase. This PR adds support for an extra argument, `-c/--camelize`, which converts all interface and attribute names to camel case in the output.